### PR TITLE
feat: 게이트웨이에 activity-service 라우팅 경로 설정 및 post-service와 activity-service 헬스 체크 추가

### DIFF
--- a/src/main/java/com/trendist/gateway_service/global/config/gateway/GatewayConfiguration.java
+++ b/src/main/java/com/trendist/gateway_service/global/config/gateway/GatewayConfiguration.java
@@ -40,7 +40,7 @@ public class GatewayConfiguration {
 			)
 
 			// 인증 필요 없는 라우트
-			.route("user_publi	c_route", r -> r.path("/users/public/**")
+			.route("user_public_route", r -> r.path("/users/public/**")
 				.filters(f -> f
 					.removeRequestHeader(HttpHeaders.COOKIE)
 				)

--- a/src/main/java/com/trendist/gateway_service/global/config/gateway/GatewayConfiguration.java
+++ b/src/main/java/com/trendist/gateway_service/global/config/gateway/GatewayConfiguration.java
@@ -40,11 +40,17 @@ public class GatewayConfiguration {
 			)
 
 			// 인증 필요 없는 라우트
-			.route("user_public_route", r -> r.path("/users/public/**")
+			.route("user_publi	c_route", r -> r.path("/users/public/**")
 				.filters(f -> f
 					.removeRequestHeader(HttpHeaders.COOKIE)
 				)
 				.uri("lb://USER-SERVICE"))
+
+			// Activity 서비스  라우트 설정
+			.route("activity-service_route", r -> r.path("/global/activities/**")
+				.filters(f -> f
+					.removeRequestHeader(HttpHeaders.COOKIE))
+				.uri("lb://ACTIVITY-SERVICE"))
 
 			.build();
 	}

--- a/src/main/java/com/trendist/gateway_service/global/config/health/HealthCheckConfiguration.java
+++ b/src/main/java/com/trendist/gateway_service/global/config/health/HealthCheckConfiguration.java
@@ -43,12 +43,13 @@ public class HealthCheckConfiguration {
 
 			// 각 서비스에 대한 health indicator 추가
 			healthChecks.put("user-service", getHealth("http://user-service"));
+			healthChecks.put("post-service", getHealth("http://post-service"));
+			healthChecks.put("activity-service", getHealth("http://activity-service"));
+
 
             /* 추후에 각 서비스들 구현시 추가
-            healthChecks.put("post-service", getHealth("http://post-service"));
             healthChecks.put("review-service", getHealth("http://review-service"));
             healthChecks.put("comment-service", getHealth("http://comment-service"));
-            healthChecks.put("activity-service", getHealth("http://activity-service"));
             healthChecks.put("issue-service", getHealth("http://issue-service"));
              */
 


### PR DESCRIPTION
## ✅  PR 유형

어떤 변경 사항이 있었나요?

- [✅] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
1. 유레카 서버와 게이트웨이에 activity-service를 추가하여 정상적으로 등록되게 했습니다.
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/26694f84-5262-46a9-919b-06202175c5ae" />

2. Post-service와 activity-service의 헬스 상태를 확인한 수 있는 indicator도 추가하였습니다.
<img width="445" alt="image" src="https://github.com/user-attachments/assets/74e0b126-ab06-4060-a7b6-e12d416ffee8" />

---

## 🔗 관련 이슈

- close #5 

---

## 💡 추가 사항
이제 초키 세팅이 완료되어서 activity-service 구현에 들어가겠습니다.
